### PR TITLE
Fix ckcov null cell #500 (#501)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -83,6 +83,10 @@
             "name": "Gavin Medley"
         },
         {
+            "affiliation": "Laboratory for Atmospheric and Space Physics, University of Colorado",
+            "name": "Chris Jeppesen"
+        },
+        {
             "orcid": "0000-0001-9798-1797",
             "affiliation": "University of California, Los Angeles",
             "name": "Jean-Luc Margot"

--- a/src/spiceypy/spiceypy.py
+++ b/src/spiceypy/spiceypy.py
@@ -429,8 +429,11 @@ def bltfrm(frmcls: int, out_cell: Optional[SpiceCell] = None) -> SpiceCell:
     :return: Set of ID codes of frames of the specified class.
     """
     frmcls = ctypes.c_int(frmcls)
-    if not out_cell:
+    if out_cell is None:
         out_cell = stypes.SPICEINT_CELL(1000)
+    else:
+        assert isinstance(out_cell, stypes.SpiceCell)
+        assert out_cell.is_int()
     libspice.bltfrm_c(frmcls, out_cell)
     return out_cell
 
@@ -1102,8 +1105,11 @@ def ckcov(
     level = stypes.string_to_char_p(level)
     tol = ctypes.c_double(tol)
     timsys = stypes.string_to_char_p(timsys)
-    if not cover:
+    if cover is None:
         cover = stypes.SPICEDOUBLE_CELL(20000)
+    else:
+        assert isinstance(cover, stypes.SpiceCell)
+        assert cover.is_double()
     assert isinstance(cover, stypes.SpiceCell)
     assert cover.dtype == 1
     libspice.ckcov_c(ck, idcode, needav, level, tol, timsys, ctypes.byref(cover))
@@ -1375,8 +1381,11 @@ def ckobj(ck: str, out_cell: Optional[SpiceCell] = None) -> SpiceCell:
     """
     assert isinstance(ck, str)
     ck = stypes.string_to_char_p(ck)
-    if not out_cell:
+    if out_cell is None:
         out_cell = stypes.SPICEINT_CELL(1000)
+    else:
+        assert isinstance(out_cell, stypes.SpiceCell)
+        assert out_cell.is_int()
     assert isinstance(out_cell, stypes.SpiceCell)
     assert out_cell.dtype == 2
     libspice.ckobj_c(ck, ctypes.byref(out_cell))
@@ -8707,8 +8716,11 @@ def kplfrm(frmcls: int, out_cell: Optional[SpiceCell] = None) -> SpiceCell:
     :param out_cell: Optional output Spice Int Cell
     :return: Set of ID codes of frames of the specified class.
     """
-    if not out_cell:
+    if out_cell is None:
         out_cell = stypes.SPICEINT_CELL(1000)
+    else:
+        assert isinstance(out_cell, stypes.SpiceCell)
+        assert out_cell.is_int()
     frmcls = ctypes.c_int(frmcls)
     libspice.kplfrm_c(frmcls, ctypes.byref(out_cell))
     return out_cell
@@ -13018,8 +13030,11 @@ def spkobj(spk: str, out_cell: Optional[SpiceCell] = None) -> SpiceCell:
     :param out_cell: Optional Spice Int Cell.
     """
     spk = stypes.string_to_char_p(spk)
-    if not out_cell:
+    if out_cell is None:
         out_cell = stypes.SPICEINT_CELL(1000)
+    else:
+        assert isinstance(out_cell, stypes.SpiceCell)
+        assert out_cell.is_int()
     assert isinstance(out_cell, stypes.SpiceCell)
     assert out_cell.dtype == 2
     libspice.spkobj_c(spk, ctypes.byref(out_cell))

--- a/src/spiceypy/tests/gettestkernels.py
+++ b/src/spiceypy/tests/gettestkernels.py
@@ -85,6 +85,8 @@ def cleanup_cassini_kernels() -> None:
 class ExtraKernels(object):
     voyagerSclk_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/main/vg200022.tsc"
     voyagerSclk_md5 = "4bcaf22788efbd86707c4b3c4d63c0c3"
+    v1jCk_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/main/vg1_jup_version1_type1_iss_sedr.bc"
+    v1jCk_md5 = "92ac30ccb1c1de6149058aef342da593"
     earthTopoTf_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/main/earth_topo_050714.tf"
     earthTopoTf_md5 = "fbde06c5abc5da969db984bb4ce5e6e0"
     earthStnSpk_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/main/earthstns_itrf93_050714.bsp"
@@ -108,6 +110,7 @@ class ExtraKernels(object):
     v02swuck_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/main/vo2_swu_ck2.bc"
     v02swuck_md5 = "f59ef0556dfc63b55465e152f2d6f5a4"
     voyagerSclk = get_path_from_url(voyagerSclk_url)
+    v1jCk = get_path_from_url(v1jCk_url)
     earthTopoTf = get_path_from_url(earthTopoTf_url)
     earthStnSpk = get_path_from_url(earthStnSpk_url)
     earthHighPerPck = get_path_from_url(earthHighPerPck_url)
@@ -123,6 +126,7 @@ class ExtraKernels(object):
 
 def cleanup_extra_kernels() -> None:
     cleanup_file(ExtraKernels.voyagerSclk)
+    cleanup_file(ExtraKernels.v1jCk)
     cleanup_file(ExtraKernels.earthTopoTf)
     cleanup_file(ExtraKernels.earthStnSpk)
     cleanup_file(ExtraKernels.earthHighPerPck)
@@ -256,6 +260,7 @@ def get_standard_kernels() -> None:
 def get_extra_test_kernels() -> None:
     # these are test kernels not included in the standard meta kernel
     get_kernel(ExtraKernels.voyagerSclk_url, ExtraKernels.voyagerSclk_md5)
+    get_kernel(ExtraKernels.v1jCk_url, ExtraKernels.v1jCk_md5)
     get_kernel(ExtraKernels.earthTopoTf_url, ExtraKernels.earthTopoTf_md5)
     get_kernel(ExtraKernels.earthStnSpk_url, ExtraKernels.earthStnSpk_md5)
     get_kernel(ExtraKernels.earthHighPerPck_url, ExtraKernels.earthHighPerPck_md5)

--- a/src/spiceypy/tests/test_support_types.py
+++ b/src/spiceypy/tests/test_support_types.py
@@ -74,6 +74,22 @@ def test_SpiceCell():
     assert str(test_cell).startswith("<SpiceCell")
 
 
+def test_spicecell_false():
+    test_cell = stypes.SPICEINT_CELL(8)
+    assert not test_cell
+
+
+def test_spicecell_len0():
+    test_cell = stypes.SPICEINT_CELL(8)
+    assert len(test_cell)==0
+
+
+def test_spicecell_true():
+    test_cell = stypes.SPICEINT_CELL(8)
+    spice.appndi(1, test_cell)
+    assert test_cell
+
+
 def test_spicecell_equality():
     c1 = stypes.Cell_Int(8)
     spice.appndi([1, 2, 3], c1)

--- a/src/spiceypy/tests/test_wrapper.py
+++ b/src/spiceypy/tests/test_wrapper.py
@@ -42,6 +42,7 @@ from spiceypy.tests.gettestkernels import (
     cleanup_core_kernels,
     cwd,
 )
+from spiceypy.utils.support_types import SPICEDOUBLE_CELL
 
 
 @pytest.fixture(autouse=True)
@@ -547,6 +548,12 @@ def test_ckcov():
     assert [
         [cover[i * 2], cover[i * 2 + 1]] for i in range(spice.wncard(cover))
     ] == expected_intervals
+    
+    
+def test_ckcov2():
+    ckid = spice.ckobj(ExtraKernels.v1jCk)[0]
+    cover = SPICEDOUBLE_CELL(200000)
+    cover = spice.ckcov(ExtraKernels.v1jCk, ckid, False, "INTERVAL", 0.0, "SCLK", cover)
 
 
 def test_ckfrot():


### PR DESCRIPTION
* Corrected bug where bool was used instead of is Null for specifying return SpiceCell in  `bltfrm()`,  `ckcov()`, `ckobj()`, `kplfrm()`, `spkobj()`
* Add assertions that passed-in SpiceCell is correct type
* Add assertions that verify bool() and len() act as they did for SpiceyPy 6.0.2 (and before)
* Added tests to cover current/past behavior to see if regressions occur